### PR TITLE
Make neo_zoom() return boolean

### DIFF
--- a/lua/neo-zoom.lua
+++ b/lua/neo-zoom.lua
@@ -51,7 +51,7 @@ function M.neo_zoom()
         and vim.api.nvim_win_get_config(0).relative == '')
       or _in_table(M.exclude_filetypes, vim.bo.filetype)
     ) then
-    return
+    return false
   end
   local uis = vim.api.nvim_list_uis()[1]
   local editor_width = uis.width
@@ -68,7 +68,7 @@ function M.neo_zoom()
     
     M.WIN_ON_ENTER = nil
     M.FLOAT_WIN = nil
-    return
+    return true
   end
 
   M.WIN_ON_ENTER = vim.api.nvim_get_current_win()
@@ -87,6 +87,7 @@ function M.neo_zoom()
   vim.api.nvim_set_current_buf(cur_buf)
 
   pin_to_scrolloff()
+  return true
 end
 
 local function setup_vim_commands()


### PR DESCRIPTION
Without this, it's not possible to know if the toggle was skipped due to e.g. the buffer being a terminal or the filetype being in the exclude list. This makes it difficult and awkward to code around those situations in custom configuration. By making it a boolean, we can call the function directly (rather than using vim cmd) and use the result to know if it was skipped or not.